### PR TITLE
156-feature/docker compose for testing propouses with postgres and pg…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+#Db volumen
+postgres_data
 
 # dependencies
 node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,30 @@
 version: '3.8'
 services:
   postgres:
-    image: postgres:13
+    image: postgres
     environment:
-      POSTGRES_DB: my_db
       POSTGRES_USER: root
-      POSTGRES_PASSWORD: 123456
-    restart: always
+      POSTGRES_PASSWORD: admin
+    restart: unless-stopped
     ports:
       - 5432:5432
     volumes:
       - ./postgres_data:/var/lib/postgresql/data
+    networks:
+      - rewards
+  
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-pgadmin4@pgadmin.org}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
+    ports:
+      - "5050:80"
+    networks:
+      - rewards
+    restart: unless-stopped
+networks:
+  rewards:
+    driver: bridge


### PR DESCRIPTION
## Description

it was added the db connection and client for testing propose 

## Related Issue

Please link to the issue here: https://github.com/serudda/reward-system/issues/156

## Motivation and Context

Now is not needed a supabase account in order to test the repository. 
This could be the entry point of a dockerization of the application.

## How Has This Been Tested

to run docker compose it is possible with the command

```
docker compose up -d
```
when the installation is done, call the following address to display the Db client

```
localhost:5050
```

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Did you maintain or improve the quality of the project? Put an `x` in all the boxes that apply: -->

- [x] My code follows the code style this project.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
