### PR TITLE
refactor Config packge: 0.1.0 alpha.2 → 0.1.0 alpha.3 (patch)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 /** @type {import("eslint").Linter.Config} */
 const config = {
   root: true,
-  extends: ['acme'], // uses the config in `packages/config/eslint`
+  extends: ["@acme/eslint-config"], // uses the config in `packages/config/eslint`
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',

--- a/apps/bot/package.json
+++ b/apps/bot/package.json
@@ -24,9 +24,9 @@
     "superjson": "1.9.1"
   },
   "devDependencies": {
+    "@acme/eslint-config": "*",
     "@types/node": "^18.11.18",
     "eslint": "^8.34.0",
-    "eslint-config-acme": "0.0.0",
     "ts-node": "^10.9.1",
     "tslib": "^2.5.0",
     "typescript": "^4.9.5"

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -32,12 +32,12 @@
     "zod": "^3.20.6"
   },
   "devDependencies": {
+    "@acme/eslint-config": "*",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "autoprefixer": "^10.4.13",
     "eslint": "^8.34.0",
-    "eslint-config-acme": "0.0.0",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.2.7",
     "tsx": "^3.12.3",

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acme/nextjs",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0",
   "private": true,
   "author": "Indie Creators HQ",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "create-t3-turbo",
   "author": "Indie Creators HQ",
+  "version": "0.1.0-alpha.3",
   "private": true,
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare": "npx husky install"
   },
   "dependencies": {
+    "@acme/eslint-config": "*",
     "@commitlint/cli": "^17.4.4",
     "@commitlint/config-conventional": "^17.4.4",
     "@ianvs/prettier-plugin-sort-imports": "^3.7.1",
@@ -29,7 +30,6 @@
     "@types/prettier": "^2.7.2",
     "dotenv-cli": "^7.0.0",
     "eslint": "^8.34.0",
-    "eslint-config-acme": "0.0.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.0",
     "prettier": "^2.8.4",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -21,8 +21,8 @@
     "zod": "^3.20.6"
   },
   "devDependencies": {
+    "@acme/eslint-config": "*",
     "eslint": "^8.34.0",
-    "eslint-config-acme": "0.0.0",
     "typescript": "^4.9.5"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -20,8 +20,8 @@
     "react-dom": "18.2.0"
   },
   "devDependencies": {
+    "@acme/eslint-config": "*",
     "eslint": "^8.34.0",
-    "eslint-config-acme": "0.0.0",
     "typescript": "^4.9.5"
   }
 }

--- a/packages/config/eslint/package.json
+++ b/packages/config/eslint/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "eslint-config-acme",
-  "version": "0.0.0",
+  "name": "@acme/eslint-config",
+  "version": "0.1.0",
   "main": "index.js",
   "license": "MIT",
   "author": "Indie Creators HQ",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ importers:
 
   .:
     specifiers:
+      '@acme/eslint-config': '*'
       '@commitlint/cli': ^17.4.4
       '@commitlint/config-conventional': ^17.4.4
       '@ianvs/prettier-plugin-sort-imports': ^3.7.1
@@ -12,7 +13,6 @@ importers:
       '@types/prettier': ^2.7.2
       dotenv-cli: ^7.0.0
       eslint: ^8.34.0
-      eslint-config-acme: 0.0.0
       husky: ^8.0.3
       lint-staged: ^13.2.0
       prettier: ^2.8.4
@@ -21,6 +21,7 @@ importers:
       turbo: ^1.8.3
       typescript: ^4.9.5
     dependencies:
+      '@acme/eslint-config': link:packages/config/eslint
       '@commitlint/cli': 17.5.0
       '@commitlint/config-conventional': 17.4.4
       '@ianvs/prettier-plugin-sort-imports': 3.7.1_prettier@2.8.4
@@ -29,7 +30,6 @@ importers:
       '@types/prettier': 2.7.2
       dotenv-cli: 7.1.0
       eslint: 8.36.0
-      eslint-config-acme: link:packages/config/eslint
       husky: 8.0.3
       lint-staged: 13.2.0
       prettier: 2.8.4
@@ -41,13 +41,13 @@ importers:
   apps/bot:
     specifiers:
       '@acme/api': '*'
+      '@acme/eslint-config': '*'
       '@acme/i18n': '*'
       '@trpc/client': ^10.14.0
       '@trpc/server': ^10.14.0
       '@types/node': ^18.11.18
       discord.js: ^14.7.1
       eslint: ^8.34.0
-      eslint-config-acme: 0.0.0
       superjson: 1.9.1
       ts-node: ^10.9.1
       tslib: ^2.5.0
@@ -60,9 +60,9 @@ importers:
       discord.js: 14.8.0
       superjson: 1.9.1
     devDependencies:
+      '@acme/eslint-config': link:../../packages/config/eslint
       '@types/node': 18.15.3
       eslint: 8.36.0
-      eslint-config-acme: link:../../packages/config/eslint
       ts-node: 10.9.1_cbfmry4sbbh4vatmdrsmatfg5a
       tslib: 2.5.0
       typescript: 4.9.5
@@ -72,6 +72,7 @@ importers:
       '@acme/api': '*'
       '@acme/auth': '*'
       '@acme/db': '*'
+      '@acme/eslint-config': '*'
       '@acme/i18n': '*'
       '@acme/tailwind-config': '*'
       '@tanstack/react-query': ^4.24.10
@@ -85,7 +86,6 @@ importers:
       autoprefixer: ^10.4.13
       classnames: ^2.3.2
       eslint: ^8.34.0
-      eslint-config-acme: 0.0.0
       next: ^13.2.3
       next-auth: ^4.20.1
       postcss: ^8.4.21
@@ -115,12 +115,12 @@ importers:
       superjson: 1.9.1
       zod: 3.21.4
     devDependencies:
+      '@acme/eslint-config': link:../../packages/config/eslint
       '@types/node': 18.15.3
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
       autoprefixer: 10.4.14_postcss@8.4.21
       eslint: 8.36.0
-      eslint-config-acme: link:../../packages/config/eslint
       postcss: 8.4.21
       tailwindcss: 3.2.7_postcss@8.4.21
       tsx: 3.12.5
@@ -130,11 +130,11 @@ importers:
     specifiers:
       '@acme/auth': '*'
       '@acme/db': '*'
+      '@acme/eslint-config': '*'
       '@acme/i18n': '*'
       '@trpc/client': ^10.14.0
       '@trpc/server': ^10.14.0
       eslint: ^8.34.0
-      eslint-config-acme: 0.0.0
       superjson: 1.9.1
       typescript: ^4.9.5
       zod: ^3.20.6
@@ -147,16 +147,16 @@ importers:
       superjson: 1.9.1
       zod: 3.21.4
     devDependencies:
+      '@acme/eslint-config': link:../config/eslint
       eslint: 8.36.0
-      eslint-config-acme: link:../config/eslint
       typescript: 4.9.5
 
   packages/auth:
     specifiers:
       '@acme/db': '*'
+      '@acme/eslint-config': '*'
       '@next-auth/prisma-adapter': ^1.0.5
       eslint: ^8.34.0
-      eslint-config-acme: 0.0.0
       next: ^13.2.3
       next-auth: ^4.20.1
       react: 18.2.0
@@ -170,8 +170,8 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
+      '@acme/eslint-config': link:../config/eslint
       eslint: 8.36.0
-      eslint-config-acme: link:../config/eslint
       typescript: 4.9.5
 
   packages/config/eslint:

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:base"],
   "packageRules": [
     {
-      "matchPackagePatterns": ["^@acme/", "eslint-config-acme"],
+      "matchPackagePatterns": ["^@acme/"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
### **Changelog 🚀** 
0.1.0-alpha.3 (Apr 06, 2023)

Fixes

- We replaced the way we called the package/config/lint, in order to align the naming with the repo template.