### PR TITLE
[RS-220] Include a role validation in give-coins command

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,8 +27,6 @@ jobs:
       - name: Get Reward from Github Issue
         uses: octokit/graphql-action@v2.x
         id: get_reward
-        env:
-          GITHUB_TOKEN: ${{ secrets.MY_PERSONAL_TOKEN }}
         with:
           query: |
             query GetCoinsAndAssigneeUser($owner:String!, $repo:String!, $issue:Int!, $field: String!) {
@@ -59,6 +57,8 @@ jobs:
           repo: ${{ github.event.repository.name }}
           issue: ${{ steps.get_issue_number.outputs.issue_number_int }}
           field: ${{ vars.REWARD_FIELD_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_PERSONAL_TOKEN }}
 
       - name: Set Variables to Send Coins
         id: vars_send_coins

--- a/apps/bot/src/slashCommands/giveCoins.ts
+++ b/apps/bot/src/slashCommands/giveCoins.ts
@@ -1,7 +1,14 @@
-import { SlashCommandBuilder, type CacheType, type CommandInteraction, type User as UserDiscord } from 'discord.js';
+import {
+  SlashCommandBuilder,
+  type CacheType,
+  type CommandInteraction,
+  type PermissionResolvable,
+  type User as UserDiscord,
+} from 'discord.js';
 import { i18n } from '@acme/i18n';
 import { type SlashCommand } from '../@types/discord';
 import { api } from '../api';
+import { config } from '../common/constants';
 
 const showSentCoinsMsg = (interaction: CommandInteraction<CacheType>, coins: string) => {
   const receiver = interaction.options.getUser('user');
@@ -9,7 +16,6 @@ const showSentCoinsMsg = (interaction: CommandInteraction<CacheType>, coins: str
     sender: `<@${interaction.user.id}>`,
     coins,
     receiver: `<@${receiver?.id}>`,
-    ephemeral: true,
   });
 
   void interaction.reply(message);
@@ -32,10 +38,17 @@ const command: SlashCommand = {
       // TODO: Fix an Type issue with .getString, it is not recognized as a function
       const coins: string = (interaction.options as any).getString('coins'); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
 
+      // Check if the user has the role Admin
+      if (!interaction.memberPermissions?.has(config.roleAdminId as PermissionResolvable)) {
+        const message = i18n.t('bot:common.error.notAllowed');
+        await interaction.reply({ content: message, ephemeral: true });
+        return;
+      }
+
       // Check if user is trying to send less than 1 coins
       if (parseInt(coins) < 1) {
-        const message = i18n.t('bot:common.error.invalidAmount', { ephemeral: true });
-        await interaction.reply(message);
+        const message = i18n.t('bot:common.error.invalidAmount');
+        await interaction.reply({ content: message, ephemeral: true });
         return;
       }
 

--- a/apps/bot/src/slashCommands/pay.ts
+++ b/apps/bot/src/slashCommands/pay.ts
@@ -9,7 +9,6 @@ const showSentCoinsMsg = (interaction: CommandInteraction<CacheType>, coins: str
     sender: `<@${interaction.user.id}>`,
     coins,
     receiver: `<@${receiver?.id}>`,
-    ephemeral: true,
   });
 
   void interaction.reply(message);

--- a/packages/config/i18n/src/locale/en/bot.json
+++ b/packages/config/i18n/src/locale/en/bot.json
@@ -1,7 +1,8 @@
 {
   "common": {
     "error": {
-      "invalidAmount": "You can not give less than 1 coin"
+      "invalidAmount": "You can not give less than 1 coin",
+      "notAllowed": "You do not have permission to use this command"
     }
   },
   "command": {

--- a/packages/config/i18n/src/locale/es/bot.json
+++ b/packages/config/i18n/src/locale/es/bot.json
@@ -1,7 +1,8 @@
 {
   "common": {
     "error": {
-      "invalidAmount": "You can not give less than 1 coin"
+      "invalidAmount": "You can not give less than 1 coin",
+      "notAllowed": "No tienes permiso para usar este comando"
     }
   },
   "command": {


### PR DESCRIPTION
## Changes Made 🎉

- [ ] feat: added new feature to improve user experience
- [x] fix: corrected a bug with login functionality
- [x] refactor: improved code readability and organization
- [ ] docs: updated README with new instructions
- [ ] chore: updated dependencies and configuration files

### Describe Changes

Any member could use the /give-coins command to allocate N amount of Indie Tokens. A validation was added so that it could only be used by an Admin.

## Related Issue(s)

https://github.com/serudda/reward-system/issues/220

## Visuals (Optional)

<!--- Add video or images showcasing the changes or demonstrating the functionality --->

## Checklist ✅

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
